### PR TITLE
Fix Windows native UI launch by honoring `claudeProcessWrapper`

### DIFF
--- a/src/commands/terminalManager.ts
+++ b/src/commands/terminalManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { resolveCliExecutable } from '../settings/cliExecutable';
 
 /**
  * Manages the OpenClaude integrated terminal instance.
@@ -30,7 +31,7 @@ export class TerminalManager implements vscode.Disposable {
     }
 
     const config = vscode.workspace.getConfiguration('openclaudeCode');
-    const cliCommand = config.get<string>('claudeProcessWrapper', '') || 'openclaude';
+    const cliCommand = resolveCliExecutable(config);
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
     const envVars = config.get<Array<{ name: string; value: string }>>(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { CheckpointManager } from './checkpoint/checkpointManager';
 import type { RewindFilesResponse } from './checkpoint/checkpointManager';
 import { AuthManager } from './auth/authManager';
 import { SettingsSync } from './settings/settingsSync';
+import { resolveCliExecutable } from './settings/cliExecutable';
 import { McpIdeServer } from './mcp/mcpIdeServer';
 import { normalizePluginState, buildToggleRequest, buildInstallCommand, buildReloadRequest } from './plugins/pluginBridge';
 import { WorktreeManager } from './worktree/worktreeManager';
@@ -217,6 +218,7 @@ export function activate(context: vscode.ExtensionContext) {
     webviewManager!.broadcast({ type: 'process_state', state: 'starting' });
 
     const config = vscode.workspace.getConfiguration('openclaudeCode');
+    const executable = resolveCliExecutable(config);
     const permissionMode = config.get<string>('initialPermissionMode') as
       | 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dontAsk' | undefined;
 
@@ -226,6 +228,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     processManager = new ProcessManager({
       cwd: workspaceFolder.uri.fsPath,
+      executable,
       model,
       permissionMode,
       env,
@@ -584,6 +587,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const config = vscode.workspace.getConfiguration('openclaudeCode');
+    const executable = resolveCliExecutable(config);
     const model = config.get<string>('selectedModel');
     const permissionMode = config.get<string>('initialPermissionMode') as
       | 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dontAsk' | undefined;
@@ -601,6 +605,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     processManager = new ProcessManager({
       cwd: workspaceFolder.uri.fsPath,
+      executable,
       model: model !== 'default' ? model : undefined,
       permissionMode,
       sessionId: message.sessionId,
@@ -746,8 +751,12 @@ export function activate(context: vscode.ExtensionContext) {
       const forkOptions = checkpointManager.buildForkOptions(msg.messageUuid);
       const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
       if (!workspaceFolder) return;
+      const executable = resolveCliExecutable(
+        vscode.workspace.getConfiguration('openclaudeCode'),
+      );
       const forkPm = new ProcessManager({
         cwd: workspaceFolder.uri.fsPath,
+        executable,
         sessionId: forkOptions.sessionId,
         forkSession: forkOptions.forkSession,
         env: authManager.buildProcessEnv(),
@@ -766,8 +775,12 @@ export function activate(context: vscode.ExtensionContext) {
       const forkOptions = checkpointManager.buildForkOptions(msg.messageUuid);
       const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
       if (!workspaceFolder) return;
+      const executable = resolveCliExecutable(
+        vscode.workspace.getConfiguration('openclaudeCode'),
+      );
       const forkPm = new ProcessManager({
         cwd: workspaceFolder.uri.fsPath,
+        executable,
         sessionId: forkOptions.sessionId,
         forkSession: forkOptions.forkSession,
         env: authManager.buildProcessEnv(),

--- a/src/process/processManager.ts
+++ b/src/process/processManager.ts
@@ -6,6 +6,7 @@
 // Reference: Claude Code extension.js class `Qm` (ProcessTransport) and `fm` (Query)
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { NdjsonTransport } from './ndjsonTransport';
 import { ControlRouter, type ControlRequestHandler } from './controlRouter';
@@ -70,6 +71,53 @@ type ErrorCallback = (error: Error) => void;
 type ExitCallback = (code: number | null, signal: string | null) => void;
 type StderrCallback = (line: string) => void;
 type StateCallback = (state: ProcessState) => void;
+
+interface SpawnCommand {
+  executable: string;
+  args: string[];
+}
+
+function isBareWindowsCommand(executable: string): boolean {
+  return !/[\\/]/.test(executable) && path.win32.extname(executable) === '';
+}
+
+function isWindowsBatchWrapper(executable: string): boolean {
+  const ext = path.win32.extname(executable).toLowerCase();
+  return ext === '.cmd' || ext === '.bat';
+}
+
+function quoteForWindowsCmd(arg: string): string {
+  if (arg.length === 0) {
+    return '""';
+  }
+
+  if (!/[\s"&()<>^|]/.test(arg)) {
+    return arg;
+  }
+
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+function resolveSpawnCommand(executable: string, args: string[]): SpawnCommand {
+  if (
+    process.platform === 'win32' &&
+    (isBareWindowsCommand(executable) || isWindowsBatchWrapper(executable))
+  ) {
+    // npm installs `openclaude` on Windows as a `.cmd` shim, which must be
+    // launched through `cmd.exe` for PATH/PATHEXT resolution to work reliably.
+    return {
+      executable: process.env.ComSpec?.trim() || 'cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        [executable, ...args].map(quoteForWindowsCmd).join(' '),
+      ],
+    };
+  }
+
+  return { executable, args };
+}
 
 // ============================================================================
 // ProcessManager
@@ -137,12 +185,13 @@ export class ProcessManager {
 
     this.setState(ProcessState.Spawning);
 
-    const executable = this.options.executable ?? 'openclaude';
+    const executable = (this.options.executable ?? 'openclaude').trim() || 'openclaude';
     const args = this.buildArgs();
     const env = this.buildEnv();
+    const spawnCommand = resolveSpawnCommand(executable, args);
 
     try {
-      this.process = spawn(executable, args, {
+      this.process = spawn(spawnCommand.executable, spawnCommand.args, {
         cwd: this.options.cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
         env,

--- a/src/settings/cliExecutable.ts
+++ b/src/settings/cliExecutable.ts
@@ -1,0 +1,10 @@
+import type * as vscode from 'vscode';
+
+export const DEFAULT_CLI_EXECUTABLE = 'openclaude';
+
+type ConfigLike = Pick<vscode.WorkspaceConfiguration, 'get'>;
+
+export function resolveCliExecutable(config: ConfigLike): string {
+  const wrapper = config.get<string>('claudeProcessWrapper', '')?.trim();
+  return wrapper || DEFAULT_CLI_EXECUTABLE;
+}

--- a/test/unit/cliExecutable.test.ts
+++ b/test/unit/cliExecutable.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCliExecutable } from '../../src/settings/cliExecutable';
+
+describe('resolveCliExecutable', () => {
+  it('uses a configured wrapper when it is non-empty', () => {
+    const config = {
+      get: (_key: string, _defaultValue?: string) => '  C:\\Tools\\openclaude.cmd  ',
+    };
+
+    expect(resolveCliExecutable(config)).toBe('C:\\Tools\\openclaude.cmd');
+  });
+
+  it('falls back to openclaude when the wrapper is empty', () => {
+    const config = {
+      get: (_key: string, _defaultValue?: string) => '   ',
+    };
+
+    expect(resolveCliExecutable(config)).toBe('openclaude');
+  });
+});

--- a/test/unit/processManager.test.ts
+++ b/test/unit/processManager.test.ts
@@ -12,6 +12,16 @@ vi.mock('node:child_process', () => ({
 // Import after mocking
 import { ProcessManager, ProcessState } from '../../src/process/processManager';
 
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalComSpec = process.env.ComSpec;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
 function createMockProcess(exitCode: number | null = null) {
   const proc = new NodeEventEmitter() as NodeEventEmitter & {
     stdin: PassThrough;
@@ -40,6 +50,8 @@ describe('ProcessManager', () => {
   let mockProc: ReturnType<typeof createMockProcess>;
 
   beforeEach(() => {
+    setPlatform('linux');
+    delete process.env.ComSpec;
     mockProc = createMockProcess();
     mockSpawn.mockReturnValue(mockProc);
     manager = new ProcessManager({
@@ -51,6 +63,15 @@ describe('ProcessManager', () => {
   afterEach(() => {
     manager.dispose();
     vi.clearAllMocks();
+
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
+    if (originalComSpec === undefined) {
+      delete process.env.ComSpec;
+    } else {
+      process.env.ComSpec = originalComSpec;
+    }
   });
 
   describe('spawn', () => {
@@ -178,6 +199,84 @@ describe('ProcessManager', () => {
         'openclaude',
         expect.arrayContaining(['--resume', 'abc-123']),
         expect.any(Object),
+      );
+    });
+
+    it('should launch bare commands through cmd.exe on Windows', () => {
+      setPlatform('win32');
+      process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+      manager = new ProcessManager({
+        cwd: 'C:\\work\\project',
+        executable: 'openclaude',
+        model: 'gpt-4o',
+        permissionMode: 'plan',
+        sessionId: 'abc-123',
+        worktree: 'feature branch',
+        env: {
+          OPENAI_API_KEY: 'sk-test',
+        },
+      });
+
+      manager.spawn();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'C:\\Windows\\System32\\cmd.exe',
+        [
+          '/d',
+          '/s',
+          '/c',
+          expect.stringContaining('openclaude'),
+        ],
+        expect.objectContaining({
+          cwd: 'C:\\work\\project',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
+          env: expect.objectContaining({
+            OPENAI_API_KEY: 'sk-test',
+          }),
+        }),
+      );
+
+      const commandLine = mockSpawn.mock.calls[0]?.[1]?.[3] as string;
+      expect(commandLine).toContain('--output-format');
+      expect(commandLine).toContain('stream-json');
+      expect(commandLine).toContain('--input-format');
+      expect(commandLine).toContain('--verbose');
+      expect(commandLine).toContain('--model');
+      expect(commandLine).toContain('gpt-4o');
+      expect(commandLine).toContain('--permission-mode');
+      expect(commandLine).toContain('plan');
+      expect(commandLine).toContain('--resume');
+      expect(commandLine).toContain('abc-123');
+      expect(commandLine).toContain('--worktree');
+      expect(commandLine).toContain('"feature branch"');
+    });
+
+    it('should launch cmd wrapper paths through cmd.exe on Windows', () => {
+      setPlatform('win32');
+      process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+      manager = new ProcessManager({
+        cwd: 'C:\\work\\project',
+        executable: 'C:\\Users\\Test User\\AppData\\Roaming\\npm\\openclaude.cmd',
+      });
+
+      manager.spawn();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'C:\\Windows\\System32\\cmd.exe',
+        [
+          '/d',
+          '/s',
+          '/c',
+          '"C:\\Users\\Test User\\AppData\\Roaming\\npm\\openclaude.cmd" --output-format stream-json --verbose --input-format stream-json',
+        ],
+        expect.objectContaining({
+          cwd: 'C:\\work\\project',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
+        }),
       );
     });
   });

--- a/test/unit/worktreeManager.test.ts
+++ b/test/unit/worktreeManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
 
 describe('WorktreeManager helpers', () => {
   describe('sanitizeWorktreeName', () => {
@@ -42,7 +43,7 @@ describe('WorktreeManager helpers', () => {
       const { deriveWorktreePath } = await import('../../src/worktree/worktreeManager');
 
       expect(deriveWorktreePath('/home/user/myrepo', 'feature-auth')).toBe(
-        '/home/user/myrepo-worktrees/feature-auth',
+        path.join('/home/user/myrepo-worktrees', 'feature-auth'),
       );
     });
 
@@ -50,7 +51,7 @@ describe('WorktreeManager helpers', () => {
       const { deriveWorktreePath } = await import('../../src/worktree/worktreeManager');
 
       expect(deriveWorktreePath('/home/user/myrepo', 'fix', '/tmp/worktrees')).toBe(
-        '/tmp/worktrees/fix',
+        path.join('/tmp/worktrees', 'fix'),
       );
     });
   });


### PR DESCRIPTION
# Summary

This PR fixes the Windows native-UI launch failure where the VS Code extension could fail with:

`OpenClaude failed to start: spawn openclaude ENOENT`

# Root cause

There were two related issues:

1. Native UI launch paths were not consistently using `openclaudeCode.claudeProcessWrapper`, even though terminal mode already had wrapper support.
2. On Windows, globally installed npm CLIs are often exposed through `.cmd` shims, and spawning a bare command directly is fragile in this path.

As a result, native UI could fall back to `openclaude` and fail with `ENOENT` even when `openclaude --version` worked in PowerShell.

# What changed

- Added a shared helper to resolve the CLI executable from VS Code settings.
  - Uses `openclaudeCode.claudeProcessWrapper` when set
  - Falls back to `openclaude` otherwise
- Reused that helper in both terminal mode and native UI launch paths
- Passed `executable` into every `ProcessManager` construction in `src/extension.ts`
  - initial spawn
  - resume flow
  - `fork_session`
  - `fork_and_rewind`
- Added a Windows-specific spawn strategy in `ProcessManager`
  - when the executable is a bare command or a `.cmd` / `.bat` wrapper, launch through `cmd.exe /d /s /c ...`
  - preserves `cwd`, `env`, `stdio`, `windowsHide`, and existing CLI flags
- Added tests for:
  - executable resolution helper behavior
  - Windows launch path behavior
  - argument and option propagation
- Made one existing worktree test platform-neutral so the suite passes consistently on Windows

# Why this is safe

- Non-Windows behavior is unchanged
- Protocol handling, initialization, transport, and restart behavior were not changed
- The Windows-specific logic is narrowly scoped to process launch only

# Validation

Ran successfully:

- `npm test`
- `npm run build`

# Notes

I chose an explicit `cmd.exe` launch path instead of `shell: true` to keep argument handling predictable and avoid relying on deprecated spawn patterns with shell argument composition.