### PR TITLE
fix: Windows settings persistence and spawn ENOENT

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "openclaude-vscode",
 	"displayName": "OpenClaude VS Code",
 	"description": "OpenClaude VS Code: AI coding assistant powered by any LLM",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "HarshAgarwal1012",
 	"license": "MIT",
 	"bugs": {
@@ -130,6 +130,21 @@
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "Automatically activate the workspace's Python environment when running OpenClaude. Requires the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) extension."
+				},
+				"openclaudeCode.selectedProvider": {
+					"type": "string",
+					"default": "anthropic",
+					"description": "The selected AI provider for OpenClaude."
+				},
+				"openclaudeCode.apiKey": {
+					"type": "string",
+					"default": "",
+					"description": "API key for the selected provider."
+				},
+				"openclaudeCode.baseUrl": {
+					"type": "string",
+					"default": "",
+					"description": "Base URL for the selected provider (for custom/OpenAI-compatible providers)."
 				}
 			}
 		},

--- a/src/process/processManager.ts
+++ b/src/process/processManager.ts
@@ -196,6 +196,7 @@ export class ProcessManager {
         stdio: ['pipe', 'pipe', 'pipe'],
         env,
         windowsHide: true,
+        shell: process.platform === 'win32',
       });
     } catch (err) {
       this.setState(ProcessState.Idle);


### PR DESCRIPTION
## Summary

- **Register missing config properties** (`selectedProvider`, `apiKey`, `baseUrl`) in `package.json` under `contributes.configuration.properties` so VS Code persists them across restarts
- **Add `shell: true`** to `spawn()` options on Windows so Node.js can resolve `.cmd` shims installed by npm

## Root Causes

1. **Settings not persisting** — `settingsSync.ts` saves provider config via `vscode.workspace.getConfiguration("openclaudeCode").update()`, but these keys weren't declared in the `package.json` schema. VS Code silently drops undeclared settings on restart.

2. **`spawn openclaude ENOENT` on Windows** — npm installs CLI tools as `.cmd` files on Windows. Node's `child_process.spawn()` cannot resolve `.cmd` files without `shell: true`. While `resolveSpawnCommand` wraps with `cmd.exe`, adding `shell: true` provides a reliable fallback for edge cases (e.g. missing `ComSpec` env var).

## Fixes

Closes #4, closes #5, closes #7, closes #8

## Test plan

- [ ] On Windows: install extension, select a non-Anthropic provider, set API key/base URL, restart VS Code — settings should persist
- [ ] On Windows: send a message — CLI should spawn without ENOENT
- [ ] On macOS/Linux: verify no regression — extension starts and works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)