### PR TITLE
fix: CLI PATH resolution + permission mode reset (#13, #14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "openclaude-vscode",
 	"displayName": "OpenClaude VS Code",
 	"description": "OpenClaude VS Code: AI coding assistant powered by any LLM",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"publisher": "HarshAgarwal1012",
 	"license": "MIT",
 	"bugs": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,7 +219,12 @@ export function activate(context: vscode.ExtensionContext) {
 
     const config = vscode.workspace.getConfiguration('openclaudeCode');
     const executable = resolveCliExecutable(config);
-    const permissionMode = config.get<string>('initialPermissionMode') as
+    // Use the permission handler's current mode (reflects user's UI selection),
+    // falling back to the config default only on first launch
+    const handlerMode = permissionHandler.getMode();
+    const permissionMode = (handlerMode !== 'default'
+      ? handlerMode
+      : config.get<string>('initialPermissionMode')) as
       | 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dontAsk' | undefined;
 
     // Use AuthManager to build env vars (merges provider env + user env vars)

--- a/src/process/processManager.ts
+++ b/src/process/processManager.ts
@@ -196,7 +196,7 @@ export class ProcessManager {
         stdio: ['pipe', 'pipe', 'pipe'],
         env,
         windowsHide: true,
-        shell: process.platform === 'win32',
+        shell: true,
       });
     } catch (err) {
       this.setState(ProcessState.Idle);

--- a/webview/src/components/chat/ChatPanel.tsx
+++ b/webview/src/components/chat/ChatPanel.tsx
@@ -76,12 +76,18 @@ export function ChatPanel() {
     return !localStorage.getItem('openclaude.onboarding.dismissed');
   });
 
+  // Track whether the user has explicitly changed the permission mode this session
+  const userSetModeRef = useRef(false);
+
   // Listen for system init messages to get the initial permission mode
   useEffect(() => {
     const unsub = vscode.onMessage('cli_output', (message) => {
       const data = message.data as Record<string, unknown> | undefined;
       if (data?.type === 'system' && data.subtype === 'init' && typeof data.permissionMode === 'string') {
-        setPermissionMode(data.permissionMode as PermissionModeValue);
+        // Only apply init's permission mode if the user hasn't explicitly changed it
+        if (!userSetModeRef.current) {
+          setPermissionMode(data.permissionMode as PermissionModeValue);
+        }
       }
       // Load company announcements from init
       if (data?.type === 'system' && data.subtype === 'init' && Array.isArray(data.companyAnnouncements)) {
@@ -107,6 +113,7 @@ export function ChatPanel() {
   // Rate limit countdown timer is now handled inside ErrorBanner component
 
   const handleModeChange = useCallback((mode: PermissionModeValue) => {
+    userSetModeRef.current = true;
     setPermissionMode(mode);
     vscode.postMessage({ type: 'set_permission_mode', mode });
   }, []);
@@ -133,7 +140,7 @@ export function ChatPanel() {
           sessionTitle={sessionTitle}
           isSessionListOpen={isSessionListOpen}
           onToggleSessionList={() => setSessionListOpen(!isSessionListOpen)}
-          onNewConversation={newConversation}
+          onNewConversation={() => { userSetModeRef.current = false; newConversation(); }}
         />
 
         {/* Session list overlay */}


### PR DESCRIPTION
## Summary

- **#13 - spawn ENOENT**: Enable `shell: true` for `child_process.spawn()` on all platforms (was Windows-only). VS Code extensions don't inherit the user's shell PATH, so globally installed npm binaries like `openclaude` couldn't be found on macOS/Linux.
- **#14 - permission mode resets**: The CLI's `system/init` message was unconditionally overwriting the user's selected permission mode. Now tracks explicit user changes with a ref and skips init overrides when user has already set a mode. Also uses the handler's current mode (not config default) when spawning the CLI.

## Test plan

- [ ] Install openclaude globally via npm, verify extension starts without ENOENT
- [ ] Change permission mode to "Accept Edits", send a message, verify mode stays
- [ ] Start new conversation, verify mode resets to default correctly